### PR TITLE
add getStoreAmount

### DIFF
--- a/entities/items/Items.simba
+++ b/entities/items/Items.simba
@@ -352,6 +352,17 @@ begin
   result := Self.findIn(AREA_MS, Pnt);
 end;
 
+function TItem.getStoreAmount(): Integer; overload;
+var
+  i,c : Integer;
+  pnt : TPoint;
+begin
+  result := 0;
+
+  if Self.findIn([30,60,475,160], pnt) then
+    exit(getItemAmount(pnt));
+end;
+
 function isBankOpen(): Boolean; forward;
 function TItem.getAmount(ExcludeBank: Boolean): Integer;
 var


### PR DESCRIPTION
New function in Items that returns the amount of a dtm in the 'Store' box. So backpack exluded -> only return the amount of items that you can buy.

For personal use I changed the getItemAmount that can exlude bank and/or backpack but that would require all scripts to update their calls so that's a nogo :-1: 
